### PR TITLE
Allow Bandcamp to parse and download all albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ soundscrape sly-dogg -d
 Folders
 --------
 
-By default, SoundScrape aims to act like _wget_, downloading in place in the current directory. With the *-f* argument, however, SoundScrape acts more like a download manager and sorts songs in to ./ARTIST_NAME/ARTIST_NAME_SONG_TITLE.mp3 format. It will also skip previously downloaded tracks.
+By default, SoundScrape aims to act like _wget_, downloading in place in the current directory. With the *-f* argument, however, SoundScrape acts more like a download manager and sorts songs into the following format:
+
+```
+./ARTIST_NAME - ALBUM_NAME/SONG_NUMBER - SONG_TITLE.mp3
+```
+
+It will also skip previously downloaded tracks.
 
 ```bash
 soundscrape murdercitydevils -f
@@ -98,6 +104,8 @@ Bandcamp
 --------
 
 SoundScrape can also pull down albums from Bandcamp. For Bandcamp pages, use the *-b* argument along with an artist's username or a specific URL. It only downloads one album at a time. This works with all of the other arguments, except *-d* as Bandcamp streams only come at one bitrate, as far as I can tell.
+
+Note: Currently, when using the *-n* argument, the limit is evaluated for each album separately.
 
 ```bash
 soundscrape warsaw -b -f

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -247,22 +247,22 @@ def process_bandcamp(vargs):
 
 # Largely borrowed from Ronier's bandcampscrape
 def scrape_bandcamp_url(url, num_tracks=sys.maxint, folders=False):
-	"""
-	Pull out artist and track info from a Bandcamp URL.
-	"""
+    """
+    Pull out artist and track info from a Bandcamp URL.
+    """
 
-	filenames = []
-	album_data = get_bandcamp_metadata(url)
+    filenames = []
+    album_data = get_bandcamp_metadata(url)
 
-	# If it's a list, we're dealing with a list of Album URLs,
-	# so we call the scrape_bandcamp_url() method for each one
-	if type(album_data) is list:
-		for album_url in album_data:
-			filenames.append(scrape_bandcamp_url(album_url,num_tracks,folders))
-		return filenames
+    # If it's a list, we're dealing with a list of Album URLs,
+    # so we call the scrape_bandcamp_url() method for each one
+    if type(album_data) is list:
+        for album_url in album_data:
+            filenames.append(scrape_bandcamp_url(album_url,num_tracks,folders))
+        return filenames
 
-	artist = album_data["artist"]
-	album_name = album_data["current"]["title"]
+    artist = album_data["artist"]
+    album_name = album_data["current"]["title"]
 
     if folders:
         directory = artist + " - " + album_name
@@ -314,28 +314,28 @@ def scrape_bandcamp_url(url, num_tracks=sys.maxint, folders=False):
 
 
 def get_bandcamp_metadata(url):
-	"""
-	Read information from the Bandcamp JavaScript object.
-	The method may return a list of URLs (indicating this is probably a "main" page which links to one or more albums), or a JSON if we can already parse album/track info from the given url.
-	The JSON is "sloppy". The native python JSON parser often can't deal, so we use the more tolerant demjson instead.
-	"""
-	request = requests.get(url)
-	try:
-		sloppy_json = request.text.split("var TralbumData = ")
-		sloppy_json = sloppy_json[1].replace('" + "', "")
-		sloppy_json = sloppy_json.replace("'", "\'")
-		sloppy_json = sloppy_json.split("};")[0] + "};"
-		sloppy_json = sloppy_json.replace("};", "}")
-		return demjson.decode(sloppy_json)
-	except Exception, e:
-		regex_all_albums = r'<a href="(/album/[^>]+)">'
-		all_albums = re.findall(regex_all_albums,request.text,re.MULTILINE)
-		all_albums = set(all_albums)
-		album_url_list = list()
-		for album in all_albums:
-			album_url = re.sub(r'music/?$','',url) + album
-			album_url_list.append(album_url)
-		return album_url_list
+    """
+    Read information from the Bandcamp JavaScript object.
+    The method may return a list of URLs (indicating this is probably a "main" page which links to one or more albums), or a JSON if we can already parse album/track info from the given url.
+    The JSON is "sloppy". The native python JSON parser often can't deal, so we use the more tolerant demjson instead.
+    """
+    request = requests.get(url)
+    try:
+        sloppy_json = request.text.split("var TralbumData = ")
+        sloppy_json = sloppy_json[1].replace('" + "', "")
+        sloppy_json = sloppy_json.replace("'", "\'")
+        sloppy_json = sloppy_json.split("};")[0] + "};"
+        sloppy_json = sloppy_json.replace("};", "}")
+        return demjson.decode(sloppy_json)
+    except Exception, e:
+        regex_all_albums = r'<a href="(/album/[^>]+)">'
+        all_albums = re.findall(regex_all_albums,request.text,re.MULTILINE)
+        all_albums = set(all_albums)
+        album_url_list = list()
+        for album in all_albums:
+            album_url = re.sub(r'music/?$','',url) + album
+            album_url_list.append(album_url)
+        return album_url_list
 
 ####################################################################
 # Mixcloud

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -16,10 +16,14 @@ from subprocess import Popen, PIPE
 from os.path import exists, join
 from os import mkdir
 
+####################################################################
+
 # Please be nice with this!
 CLIENT_ID = '22e566527758690e6feb2b5cb300cc43'
 CLIENT_SECRET = '3a7815c3f9a82c3448ee4e7d3aa484a4'
 MAGIC_CLIENT_ID = 'b45b1aa10f1ac2941910a7f0d10f8e28'
+
+####################################################################
 
 def main():
     """
@@ -68,9 +72,9 @@ def main():
     else:
         process_soundcloud(vargs)
 
-##
+####################################################################
 # SoundCloud
-##
+####################################################################
 
 def process_soundcloud(vargs):
     """
@@ -218,9 +222,9 @@ def download_tracks(client, tracks, num_tracks=sys.maxint, downloadable=False, f
 
     return filenames
 
-##
+####################################################################
 # Bandcamp
-##
+####################################################################
 
 def process_bandcamp(vargs):
     """
@@ -318,9 +322,9 @@ def get_bandcamp_metadata(url):
     sloppy_json = sloppy_json.replace("};", "}")
     return demjson.decode(sloppy_json)
 
-##
-# Bandcamp
-##
+####################################################################
+# Mixcloud
+####################################################################
 
 def process_mixcloud(vargs):
     """
@@ -430,9 +434,9 @@ def get_mixcloud_data(url):
 
     return data
 
-##
+####################################################################
 # Audiomack
-##
+####################################################################
 
 def process_audiomack(vargs):
     """
@@ -516,9 +520,10 @@ def get_audiomack_data(url):
     data['year'] = None
 
     return data
-##
+
+####################################################################
 # File Utility
-##
+####################################################################
 
 def download_file(url, path):
     """
@@ -605,9 +610,9 @@ def sanitize_filename(filename):
     sanitized_filename = re.sub(r'[/\\:*?"<>|]', '-', filename)
     return sanitized_filename
 
-##
+####################################################################
 # Main
-##
+####################################################################
 
 if __name__ == '__main__':
     try:

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -247,16 +247,22 @@ def process_bandcamp(vargs):
 
 # Largely borrowed from Ronier's bandcampscrape
 def scrape_bandcamp_url(url, num_tracks=sys.maxint, folders=False):
-    """
-    Pull out artist and track info from a Bandcamp URL.
-    """
+	"""
+	Pull out artist and track info from a Bandcamp URL.
+	"""
 
-    album_data = get_bandcamp_metadata(url)
+	filenames = []
+	album_data = get_bandcamp_metadata(url)
 
-    artist = album_data["artist"]
-    album_name = album_data["current"]["title"]
+	# If it's a list, we're dealing with a list of Album URLs,
+	# so we call the scrape_bandcamp_url() method for each one
+	if type(album_data) is list:
+		for album_url in album_data:
+			filenames.append(scrape_bandcamp_url(album_url,num_tracks,folders))
+		return filenames
 
-    filenames = []
+	artist = album_data["artist"]
+	album_name = album_data["current"]["title"]
 
     if folders:
         directory = artist + " - " + album_name
@@ -308,19 +314,28 @@ def scrape_bandcamp_url(url, num_tracks=sys.maxint, folders=False):
 
 
 def get_bandcamp_metadata(url):
-    """
-    Read information from the Bandcamp JavaScript object.
-
-    Sloppy. The native python JSON parser often can't deal, so we use the more tolerant demjson instead.
-
-    """
-    request = requests.get(url)
-    sloppy_json = request.text.split("var TralbumData = ")
-    sloppy_json = sloppy_json[1].replace('" + "', "")
-    sloppy_json = sloppy_json.replace("'", "\'")
-    sloppy_json = sloppy_json.split("};")[0] + "};"
-    sloppy_json = sloppy_json.replace("};", "}")
-    return demjson.decode(sloppy_json)
+	"""
+	Read information from the Bandcamp JavaScript object.
+	The method may return a list of URLs (indicating this is probably a "main" page which links to one or more albums), or a JSON if we can already parse album/track info from the given url.
+	The JSON is "sloppy". The native python JSON parser often can't deal, so we use the more tolerant demjson instead.
+	"""
+	request = requests.get(url)
+	try:
+		sloppy_json = request.text.split("var TralbumData = ")
+		sloppy_json = sloppy_json[1].replace('" + "', "")
+		sloppy_json = sloppy_json.replace("'", "\'")
+		sloppy_json = sloppy_json.split("};")[0] + "};"
+		sloppy_json = sloppy_json.replace("};", "}")
+		return demjson.decode(sloppy_json)
+	except Exception, e:
+		regex_all_albums = r'<a href="(/album/[^>]+)">'
+		all_albums = re.findall(regex_all_albums,request.text,re.MULTILINE)
+		all_albums = set(all_albums)
+		album_url_list = list()
+		for album in all_albums:
+			album_url = re.sub(r'music/?$','',url) + album
+			album_url_list.append(album_url)
+		return album_url_list
 
 ####################################################################
 # Mixcloud

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -236,7 +236,7 @@ def process_bandcamp(vargs):
     if 'bandcamp.com' in artist_url:
         bc_url = artist_url
     else:
-        bc_url = 'https://' + artist_url + '.bandcamp.com'
+        bc_url = 'https://' + artist_url + '.bandcamp.com/music'
 
     filenames = scrape_bandcamp_url(bc_url, num_tracks=vargs['num_tracks'], folders=vargs['folders'])
 


### PR DESCRIPTION
Hello,

First of all, thanks in advance for this great tool. :smile:
I'm really happy with all the work you and others have put into this and I hope my commits may be helpful.

Before going any further, it is worth mentioning how some special Bandcamp pages seem to work:
```
....bandcamp.com/releases    ==>    mirrors the page of the artist's latest album
....bandcamp.com/music       ==>    shows a grid with all albums of the band
....bandcamp.com/merch       ==>    shows a bunch of merchandise
```

The main URL (....bandcamp.com) usually mirrors one of those.

Here's an example where **/releases** is mirrored: https://mothermooch.bandcamp.com/
Here's an example where **/music** is mirrored: https://mississippibones.bandcamp.com/
<sub>(examples checked as of 2015/October/31 - may differ in the future)</sub>
<sub>(I can't find any examples right now, but I'm 100% sure some bands choose to mirror **/merch**)</sub>

While testing **SoundScraper**, I couldn't download all albums from a certain band.
This band's main URL was mirroring **/music**, so it couldn't be parsed correctly.
**SoundScraper** would also fail for any artists mirroring **/merch**, for obvious reasons.

So, these are my main proposed additions with this Pull Request:
**[1]** The **/music** page is now accessed when only the artist's username is provided
**[2]** The **/music** page is now parsed, recursively calling the relevant method for each album URL

This only introduces a small bug: the limit of tracks is applied for each album separately. 
It's like "*num_tracks*" actually means "*num_tracks_per_album*".
<sub>(if num_tracks=2 and the band has 5 albums, you're going to download 10 tracks)</sub>
I'm sure it's an easy fix, but I didn't have time to give it a closer look. :neutral_face:

I'm kinda busy and had to use the browser editor to commit my changes, so I may have messed up the indentation. Sorry. :expressionless:

Best regards,

Antonio