### PR TITLE
Implementing suggestions from issue #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,146 +3,90 @@
 SoundScrape [![Build Status](https://travis-ci.org/Miserlou/SoundScrape.svg)](https://travis-ci.org/Miserlou/SoundScrape) [![PyPI](https://img.shields.io/pypi/dm/SoundScrape.svg?style=flat)](https://pypi.python.org/pypi/soundscrape/) [![Python 2](https://img.shields.io/badge/Python-2-brightgreen.svg)](https://pypi.python.org/pypi/soundscrape/) [![Python 3](https://img.shields.io/badge/Python-3-brightgreen.svg)](https://pypi.python.org/pypi/soundscrape/)
 ==============
 
-**SoundScrape** makes it super easy to download artists from SoundCloud (and Bandcamp and MixCloud) - even those which don't have download links! It automatically creates ID3 tags as well (including album art), which is handy.
+**SoundScrape** makes it super easy to download artists from SoundCloud (and Bandcamp and MixCloud and AudioMack) - even those which don't have download links! It automatically creates ID3 tags as well (including album art), which is handy.
 
-Usage
+Is it easy to use?
 ---------
-
-First, install it:
-
+Install. Call it with the name of a _SoundCloud_ artist. Done.
 ```bash
 pip install soundscrape
-```
-
-Then, just call soundscrape and the name of the artist you want to scrape:
-
-```bash
 soundscrape rabbit-i-am
 ```
 
-And you're done! Hooray! Files are stored as mp3s in the format **Artist name - Track title.mp3**.
+General Usage (all supported websites)
+---------
+Files are stored in the current folder:  
+" _Artist Name - Track Title.mpX_ " <sub>(mp3 or mp4)</sub>
 
-You can also use the *-n* argument to only download a certain number of songs.
+Using the _**-f**_ argument will automatically download files into folders:  
+" _Artist Name - Album Name / 02 - Second Song.mpX_ "
 
+You can use the _**-n**_ argument to only download a certain number of songs:
 ```bash
 soundscrape rabbit-i-am -n 3
 ```
+SoundScrape skips already downloaded songs, unless you use the _**-r**_ argument.
 
-Sets
--------
+Using a full URL usually works as well, identifying which website you're trying to download from:
+```bash
+soundscrape https://mississippibones.bandcamp.com/
+```
+As a convenience method, SoundScrape can automatically _'open'_ downloaded files, using your system's _'open'_ command for file associations:
+```bash
+soundscrape lorn -of
+```
 
-Soundscrape can also download sets, but you have to include the full URL of the set you want to download:
+SoundCloud
+---------
 
+Download a specific track (with _**-t**_ or the track URL):
+```bash
+soundscrape foolsgoldrecs -t danny-brown-dip
+soundscrape https://soundcloud.com/foolsgoldrecs/danny-brown-dip
+```
+Download an entire set (with the set URL):
 ```bash
 soundscrape https://soundcloud.com/vsauce-awesome/sets/awesome
 ```
-
-Groups
---------
-
-Soundscrape can also download tracks from SoundCloud groups with the *-g* argument.
-
+Download all of an artist's liked items (with _**-l**_ or the likes URL):
+```bash
+soundscrape troyboi -l
+soundscrape https://soundcloud.com/troyboi/likes
+```
+Download tracks from groups (with _**-g**_):
 ```bash
 soundscrape chopped-and-screwed -gn 2
 ```
-
-Tracks
---------
-
-Soundscrape can also download specific tracks with *-t*:
-
-```bash
-soundscrape foolsgoldrecs -t danny-brown-dip
-```
-
-or with just the straight URL:
-
-```bash
-soundscrape https://soundcloud.com/foolsgoldrecs/danny-brown-dip
-```
-
-Likes
---------
-
-Soundscrape can also download all of an Artist's Liked items with *-l*:
-
-```bash
-soundscrape troyboi -l
-```
-
-or with just the straight URL:
-
-```bash
-soundscrape https://soundcloud.com/troyboi/likes
-```
-
-High-Quality Downloads Only
---------
-
-By default, SoundScrape will try to rip everything it can. However, if you only want to download tracks that have an official download available (which are typically at a higher-quality 320kbps bitrate), you can use the *-d* argument.
-
+By default, SoundScrape will try to rip everything it can. However, if you only want to download tracks that have an official download available (which are typically at a higher-quality 320kbps bitrate), you can use the _**-d**_ argument:
 ```bash
 soundscrape sly-dogg -d
-```
-
-Folders
---------
-
-By default, SoundScrape aims to act like _wget_, downloading in place in the current directory. With the *-f* argument, however, SoundScrape acts more like a download manager and sorts songs into the following format:
-
-```
-./ARTIST_NAME - ALBUM_NAME/SONG_NUMBER - SONG_TITLE.mp3
-```
-
-It will also skip previously downloaded tracks.
-
-```bash
-soundscrape murdercitydevils -f
 ```
 
 Bandcamp
 --------
 
-SoundScrape can also pull down albums from Bandcamp. For Bandcamp pages, use the *-b* argument along with an artist's username or a specific URL. It only downloads one album at a time. This works with all of the other arguments, except *-d* as Bandcamp streams only come at one bitrate, as far as I can tell.
+Use the _**-b**_ argument along with an artist's username to parse the _"/music"_ page. SoundScrape will attempt to download each album and even orphan tracks.
 
-Note: Currently, when using the *-n* argument, the limit is evaluated for each album separately.
-
-```bash
-soundscrape warsaw -b -f
-```
+**Note**: Currently, when using the _**-n**_ argument, the limit is evaluated for each album separately (meaning ```soundscrape -b whalerider -n 4``` will download 4 songs from each album).
 
 Mixcloud
 --------
+SoundScrape can also grab mixes from Mixcloud. This feature is extremely experimental and is in no way guaranteed to work!
 
-SoundScrape can also grab mixes from Mixcloud. This feature is extremely expermental and is in no way guaranteed to work!
-
-Finds the original mp3 of a mix and grabs that (with tags and album art) if it can, or else just gets the raw m4a stream.
+It finds the original mp3 of a mix and grabs that (with tags and album art) if it can, or else just gets the raw m4a stream.
 
 Mixcloud currently only takes an invidiual mix. Capacity for a whole artist's profile due shortly.
-
 ```bash
 soundscrape https://www.mixcloud.com/corenewsuploads/flume-essential-mix-2015-10-03/ -of
 ```
 
 Audiomack
 --------
-
-Just for fun, SoundCloud can also download individual songs from Audiomack. Not that you'd ever want to.
-
+Just for fun, SoundScrape can also download individual songs from Audiomack (with the _**-a**_ argument). Not that you'd ever want to.
 ```bash
 soundscrape -a http://www.audiomack.com/song/bottomfeedermusic/top-shottas
 ```
 
-Opening Files
---------
-
-As a convenience method, SoundScrape can automatically _'open'_ files that it downloads. This uses your system's 'open' command for file associations.
-
-```bash
-soundscrape lorn -of
-```
-
 Issues
 -------
-
 There's probably a lot more that can be done to improve this. Please file issues if you find them!

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -690,6 +690,7 @@ def get_directory(folders, artist, album_name=None):
     """
     Retrieve the sanitized directory (creating it if necessary).
     """
+    directory = ""
     if folders:
         if album_name:
             directory = artist + " - " + album_name
@@ -705,6 +706,7 @@ def get_path(folders, directory, track_name, track_number=None, file_ext="mp3"):
     """
     Retrieve the full sanitized filepath to save the given track.
     """
+    path = ""
     if track_number and folders:
         track_filepath = '%s - %s.%s' % (track_number, track_name, file_ext)
     else:

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -194,8 +194,7 @@ def download_tracks(client, tracks, num_tracks=sys.maxsize, downloadable=False, 
             else:
                 track_artist = sanitize_filename(track['user']['username'])
                 track_title = sanitize_filename(track['title'])
-                directory = get_directory(folders, track_artist, album_name=None)
-                track_fullfilepath = get_path(folders, directory, track_title, track_number=None, file_ext="mp3")
+                track_fullfilepath = get_path(folders, track_artist, track_title, album_name=None, track_number=None, file_ext="mp3")
 
                 download_text = colored.green("Downloading")
                 if exists(track_fullfilepath):
@@ -284,9 +283,6 @@ def scrape_bandcamp_url(url, num_tracks=sys.maxsize, folders=False, redownload=F
     artist = album_data["artist"]
     album_name = album_data["album_name"]
 
-    # Set the target directory just once (out of the loop)
-    directory = get_directory(folders, artist, album_name=album_name)
-
     for i, track in enumerate(album_data["trackinfo"]):
 
         if i > num_tracks - 1:
@@ -307,7 +303,7 @@ def scrape_bandcamp_url(url, num_tracks=sys.maxsize, folders=False, redownload=F
 
             download_text = colored.green("Downloading")
 
-            path = get_path(folders, directory, track_name, track_number=track_number, file_ext="mp3")
+            path = get_path(folders, artist, track_name, album_name=album_name, track_number=track_number, file_ext="mp3")
 
             if exists(path):
                 if redownload:
@@ -425,8 +421,7 @@ def scrape_mixcloud_url(mc_url, num_tracks=sys.maxsize, folders=False, redownloa
 
     track_artist = sanitize_filename(data['artist'])
     track_title = sanitize_filename(data['title'])
-    directory = get_directory(folders, track_artist, album_name=None)
-    track_fullfilepath = get_path(folders, directory, track_title, track_number=None, file_ext=data['mp3_url'][-3:])
+    track_fullfilepath = get_path(folders, track_artist, track_title, album_name=None, track_number=None, file_ext=data['mp3_url'][-3:])
 
     download_text = colored.green("Downloading")
     if exists(track_fullfilepath):
@@ -542,8 +537,7 @@ def scrape_audiomack_url(mc_url, num_tracks=sys.maxsize, folders=False, redownlo
 
     track_artist = sanitize_filename(data['artist'])
     track_title = sanitize_filename(data['title'])
-    directory = get_directory(folders, track_artist, album_name=None)
-    track_fullfilepath = get_path(folders, directory, track_title, track_number=None, file_ext="mp3")
+    track_fullfilepath = get_path(folders, track_artist, track_title, album_name=None, track_number=None, file_ext="mp3")
 
     download_text = colored.green("Downloading")
     if exists(track_fullfilepath):
@@ -686,36 +680,27 @@ def sanitize_filename(filename):
     return sanitized_filename
 
 
-def get_directory(folders, artist, album_name=None):
-    """
-    Retrieve the sanitized directory (creating it if necessary).
-    """
-    directory = ""
-    if folders:
-        if album_name:
-            directory = artist + " - " + album_name
-        else:
-            directory = artist
-        directory = sanitize_filename(directory)
-        if not exists(directory):
-            mkdir(directory)
-    return directory
-
-
-def get_path(folders, directory, track_name, track_number=None, file_ext="mp3"):
+def get_path(folders, artist_name, track_name, album_name=None, track_number=None, file_ext="mp3"):
     """
     Retrieve the full sanitized filepath to save the given track.
+    This method creates any necessary directories.
     """
-    path = ""
     if track_number and folders:
-        track_filepath = '%s - %s.%s' % (track_number, track_name, file_ext)
+        filename = '%s - %s.%s' % (track_number, track_name, file_ext)
     else:
-        track_filepath = '%s.%s' % (track_name, file_ext)
-    track_filepath = sanitize_filename(track_filepath)
+        filename = '%s.%s' % (track_name, file_ext)
+    filename = sanitize_filename(filename)
+    artist_name = sanitize_filename(artist_name)
     if folders:
-        path = join(directory, track_filepath)
+        if album_name:
+            directory = artist_name + " - " + sanitize_filename(album_name)
+        else:
+            directory = artist_name
+        if not exists(directory):
+            mkdir(directory)
+        path = join(directory, filename)
     else:
-        path = artist + ' - ' + track_filepath
+        path = artist_name + ' - ' + filename
     return path
 
 ####################################################################

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -197,14 +197,15 @@ def download_tracks(client, tracks, num_tracks=sys.maxsize, downloadable=False, 
                 directory = get_directory(folders, track_artist, album_name=None)
                 track_fullfilepath = get_path(folders, directory, track_title, track_number=None, file_ext="mp3")
 
+                download_text = colored.green("Downloading")
                 if exists(track_fullfilepath):
                     if redownload:
-                        puts(colored.yellow("Marking track for redownload: ") + colored.white(track_title))
+                        download_text = colored.yelow("Redownloading")
                     else:
                         puts(colored.yellow("Track already downloaded: ") + colored.white(track_title))
                         continue
 
-                puts(colored.green("Downloading") + colored.white(": " + track['title']))
+                puts(download_text + colored.white(": " + track['title']))
                 if track.get('direct', False):
                     location = track['stream_url']
                 else:
@@ -292,26 +293,30 @@ def scrape_bandcamp_url(url, num_tracks=sys.maxsize, folders=False, redownload=F
             continue
 
         try:
+
             track_name = track["title"]
-            if track["track_num"]:
-                track_number = str(track["track_num"]).zfill(2)
-            else:
-                track_number = None
-
-            path = get_path(folders, directory, track_name, track_number=track_number, file_ext="mp3")
-
-            if exists(path):
-                if redownload:
-                    puts(colored.yellow("Marking track for redownload: ") + colored.white(track_name))
-                else:
-                    puts(colored.yellow("Track already downloaded: ") + colored.white(track_name))
-                    continue
 
             if not track['file']:
                 puts(colored.yellow("Track unavailble for scraping: ") + colored.white(track_name))
                 continue
 
-            puts(colored.green("Downloading") + colored.white(": " + track_name))
+            if track["track_num"]:
+                track_number = str(track["track_num"]).zfill(2)
+            else:
+                track_number = None
+
+            download_text = colored.green("Downloading")
+
+            path = get_path(folders, directory, track_name, track_number=track_number, file_ext="mp3")
+
+            if exists(path):
+                if redownload:
+                    download_text = colored.yellow("Redownloading")
+                else:
+                    puts(colored.yellow("Track already downloaded: ") + colored.white(track_name))
+                    continue
+
+            puts(download_text + colored.white(": " + track_name))
             path = download_file(track['file']['mp3-128'], path)
 
             album_year = album_data['album_release_date']
@@ -423,14 +428,15 @@ def scrape_mixcloud_url(mc_url, num_tracks=sys.maxsize, folders=False, redownloa
     directory = get_directory(folders, track_artist, album_name=None)
     track_fullfilepath = get_path(folders, directory, track_title, track_number=None, file_ext=data['mp3_url'][-3:])
 
+    download_text = colored.green("Downloading")
     if exists(track_fullfilepath):
         if redownload:
-            puts(colored.yellow("Marking track for redownload: ") + colored.white(data['title']))
+            download_text = colored.yellow("Redownloading")
         else:
             puts(colored.yellow("Track already downloaded: ") + colored.white(data['title']))
             return []
 
-    puts(colored.green("Downloading") + colored.white(': ' +  data['artist'] + " - " + data['title'] + " (" + track_fullfilepath[-4:] + ")"))
+    puts(download_text + colored.white(': ' +  data['artist'] + " - " + data['title'] + " (" + track_fullfilepath[-4:] + ")"))
     download_file(data['mp3_url'], track_fullfilepath)
     if track_fullfilepath[-4:] == '.mp3':
         tag_file(track_fullfilepath,
@@ -539,14 +545,15 @@ def scrape_audiomack_url(mc_url, num_tracks=sys.maxsize, folders=False, redownlo
     directory = get_directory(folders, track_artist, album_name=None)
     track_fullfilepath = get_path(folders, directory, track_title, track_number=None, file_ext="mp3")
 
+    download_text = colored.green("Downloading")
     if exists(track_fullfilepath):
         if redownload:
-            puts(colored.yellow("Marking track for redownload: ") + colored.white(data['title']))
+            download_text = colored.yellow("Redownloading")
         else:
             puts(colored.yellow("Track already downloaded: ") + colored.white(data['title']))
             return []
 
-    puts(colored.green("Downloading") + colored.white(': ' + data['artist'] + " - " + data['title']))
+    puts(download_text + colored.white(': ' + data['artist'] + " - " + data['title']))
     download_file(data['mp3_url'], track_fullfilepath)
     tag_file(track_fullfilepath,
             artist=data['artist'],

--- a/tests/test.py
+++ b/tests/test.py
@@ -34,7 +34,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://soundcloud.com/bxsswxrshp/the-king-is-dead-and-i-couldnt-be-happier'}
+        vargs = {'redownload': False, 'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://soundcloud.com/bxsswxrshp/the-king-is-dead-and-i-couldnt-be-happier'}
         process_soundcloud(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -47,7 +47,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://atenrays.bandcamp.com/track/who-u-think'}
+        vargs = {'redownload': False, 'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://atenrays.bandcamp.com/track/who-u-think'}
         process_bandcamp(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -60,7 +60,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://defill.bandcamp.com/track/amnesia-chamber-harvest-skit'}
+        vargs = {'redownload': False, 'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://defill.bandcamp.com/track/amnesia-chamber-harvest-skit'}
         process_bandcamp(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -79,7 +79,7 @@ class TestSoundscrape(unittest.TestCase):
         # shortest mix I could find that was still semi tolerable
         mp3_count = len(glob.glob1('', "*.mp3"))
         m4a_count = len(glob.glob1('', "*.m4a"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://www.mixcloud.com/Bobby_T_FS15/coffee-cigarettes-saturday-morning-hip-hop-fix/'}
+        vargs = {'redownload': False, 'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://www.mixcloud.com/Bobby_T_FS15/coffee-cigarettes-saturday-morning-hip-hop-fix/'}
         process_mixcloud(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         new_m4a_count = len(glob.glob1('', "*.m4a"))
@@ -96,7 +96,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'audiomack': True, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://www.audiomack.com/song/bottomfeedermusic/power'}
+        vargs = {'redownload': False, 'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'audiomack': True, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://www.audiomack.com/song/bottomfeedermusic/power'}
         process_audiomack(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)


### PR DESCRIPTION
See #43 for reference.
First commit (f290ef65c585e5ea912cc29d086778974902c375) implements the "skip already downloaded" behaviour as default for all scrapers.
Second commit (e1658f34a69e01e9b811eede499413d286a65d4c) implements the "--redownload" flag. Fourth commit (92b6d2c1fa497948e3460aa1090dc365e77ddc1c) adjusts format.

Third commit (85445fc71b4f5add8e93f32655695d219d50300b) is an attempt to clarify some features, separating which arguments work with all scrapers and which don't. Hopefully the format of my README.md is acceptable. :grin:
