### PR TITLE
Convert wav to mp3 through ffmpeg

### DIFF
--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -94,11 +94,9 @@ def main():
 
     if vargs['convert']: #Checks binary to make sure it works before allowing any conversions to go ahead
         if vargs['binary']:
+            vargs["binary"][0] = vargs["binary"][0].replace("'", "").replace('"', "")
             if os.path.isfile(vargs["binary"][0]):
-                if not set(['ffmpeg', 'avconv']).issuperset(set([os.path.basename(vargs["binary"][0])])):
-                    puts_safe(colored.red("Don't recognise") + colored.white("Disabling conversion"))
-                    vargs['convert'] = False
-                else:
+                if 'ffmpeg' in os.path.basename(vargs["binary"][0]) or 'avconv' in os.path.basename(vargs["binary"][0]):
                     try:
                         Popen(vargs["binary"][0], stdout=PIPE, stderr=PIPE).wait()
                         puts_safe(colored.blue("Using " + os.path.basename(vargs["binary"][0]) + " for conversion"))
@@ -107,10 +105,10 @@ def main():
                         vargs['convert'] = False
                         print(e)
                         puts_safe(colored.red("Don't recognise: ") + colored.yellow(vargs['binary'][0]) + colored.white(" Disabling conversion"))
-            elif not set(['ffmpeg', 'avconv']).issuperset(set(vargs['binary'])):
-                puts_safe(colored.red("Don't recognise: ") + colored.yellow(vargs['binary'][0]) + colored.white(" Disabling conversion"))
-                vargs['convert'] = False
-            else:
+                else:
+                    puts_safe(colored.red("Don't recognise") + colored.white("Disabling conversion"))
+                    vargs['convert'] = False
+            elif 'ffmpeg' in vargs['binary'][0] or 'avconv' in vargs['binary'][0]:
                 try:
                     Popen(vargs["binary"][0], stdout=PIPE, stderr=PIPE).wait()
                     puts_safe(colored.yellow("Using " + vargs['binary'][0] + " for conversion"))
@@ -119,7 +117,10 @@ def main():
                     vargs['convert'] = False
                     print(e)
                     puts_safe(colored.red("Don't recognise: ") + colored.yellow(vargs['binary'][0]) + colored.white(" Disabling conversion"))
-
+            else:
+                puts_safe(colored.red("Don't recognise: ") + colored.yellow(vargs['binary'][0]) + colored.white(" Disabling conversion"))
+                vargs['convert'] = False
+             
     if 'bandcamp.com' in artist_url or vargs['bandcamp']:
         process_bandcamp(vargs)
     elif 'mixcloud.com' in artist_url or vargs['mixcloud']:

--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -216,7 +216,7 @@ def process_soundcloud(vargs):
         if not tagged:
             wav_filename = filename[:-3] + 'wav'
             os.rename(filename, wav_filename)
-            if convert:
+            if vargs["convert"]:
                 convert_track(wav_filename)
                 tag_file(filename,
                  artist=track_data['artist'],

--- a/tests/test.py
+++ b/tests/test.py
@@ -34,7 +34,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://soundcloud.com/fzpz/revised', 'keep': True}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'convert': False, 'artist_url': 'https://soundcloud.com/fzpz/revised', 'keep': True}
         process_soundcloud(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -47,7 +47,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 1, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'puptheband', 'keep': False}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 1, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'convert': False, 'artist_url': 'puptheband', 'keep': False}
         process_soundcloud(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -61,7 +61,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         wav_count = len(glob.glob1('', "*.wav"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 1, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://soundcloud.com/coastal/major-lazer-aerosol-can-coastal-flip', 'keep': False}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 1, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'convert': True, 'artist_url': 'https://soundcloud.com/coastal/major-lazer-aerosol-can-coastal-flip', 'keep': False}
         process_soundcloud(vargs)
         new_wav_count = len(glob.glob1('', "*.wav"))
         self.assertTrue(new_wav_count > wav_count)
@@ -75,7 +75,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://atenrays.bandcamp.com/track/who-u-think'}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'convert': False, 'artist_url': 'https://atenrays.bandcamp.com/track/who-u-think'}
         process_bandcamp(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -88,7 +88,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://defill.bandcamp.com/track/amnesia-chamber-harvest-skit'}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'convert': False, 'artist_url': 'https://defill.bandcamp.com/track/amnesia-chamber-harvest-skit'}
         process_bandcamp(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)
@@ -107,7 +107,7 @@ class TestSoundscrape(unittest.TestCase):
         # shortest mix I could find that was still semi tolerable
         mp3_count = len(glob.glob1('', "*.mp3"))
         m4a_count = len(glob.glob1('', "*.m4a"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://www.mixcloud.com/Bobby_T_FS15/coffee-cigarettes-saturday-morning-hip-hop-fix/'}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'downloadable': False, 'likes': False, 'open': False, 'convert': False, 'artist_url': 'https://www.mixcloud.com/Bobby_T_FS15/coffee-cigarettes-saturday-morning-hip-hop-fix/'}
         process_mixcloud(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         new_m4a_count = len(glob.glob1('', "*.m4a"))
@@ -124,7 +124,7 @@ class TestSoundscrape(unittest.TestCase):
            os.unlink(f)
 
         mp3_count = len(glob.glob1('', "*.mp3"))
-        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'audiomack': True, 'downloadable': False, 'likes': False, 'open': False, 'artist_url': 'https://www.audiomack.com/song/bottomfeedermusic/power'}
+        vargs = {'folders': False, 'group': False, 'track': '', 'num_tracks': 9223372036854775807, 'bandcamp': False, 'audiomack': True, 'downloadable': False, 'likes': False, 'open': False, 'convert': False, 'artist_url': 'https://www.audiomack.com/song/bottomfeedermusic/power'}
         process_audiomack(vargs)
         new_mp3_count = len(glob.glob1('', "*.mp3"))
         self.assertTrue(new_mp3_count > mp3_count)


### PR DESCRIPTION
Since some Soundcloud tracks are downloaded as wav's, which means they can't be tagged. I always have to convert them to mp3 and then add their tags manually. So I'm just trying to add a way to auto-convert them and add their respective tags if so desired.

It currently uses just FFmpeg for the conversion (Might add Avconv at a later date, and allow the binary location's to be specified). I've tested this on both windows and Linux, and it seems to work fine on both.

If there is some python module for audio conversion out there, I'd switch to that. But, I personally don't know of any.

Edit: Added support for Avconv, and binary directory specification
