### PR TITLE
Time Limit for SoundCloud (Other services not implemented) - FIXED

### DIFF
--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -365,14 +365,14 @@ def download_track(track, album_name=u'', keep_previews=False, folders=False, fi
 
     return filename
 
-def resolve_time_limit(time_limit=None):
-    if time_limit is None:
-        return None
+def resolve_time_limit(time_limit=""):
+    if not time_limit:
+        return 0
     return sum(int(x) * 60 ** i for i,x in enumerate(reversed(time_limit.split(":"))))
 
 def printable_duration(duration=None):
-    if duration is None:
-        return None
+    if not duration:
+        return ""
     duration_temp = duration/1000
     return str(timedelta(seconds=duration_temp))
 
@@ -444,9 +444,10 @@ def download_tracks(client, tracks, num_tracks=sys.maxsize, downloadable=False, 
                     puts_safe(colored.yellow("Track already downloaded: ") + colored.white(track_title))
                     continue
 
-                if track_duration > resolve_time_limit(time_limit)*1000:
-                    puts_safe(colored.yellow("Track (") + colored.white(track_title) + colored.yellow(") longer than set time limit (was ") + colored.red(printable_duration(track_duration)) + colored.yellow(" with limit ") + colored.red(printable_duration(resolve_time_limit(time_limit)*1000)) + colored.yellow(")"))
-                    continue
+                if not not time_limit:
+                    if track_duration > resolve_time_limit(time_limit)*1000 and resolve_time_limit(time_limit) is not 0:
+                        puts_safe(colored.yellow("Track (") + colored.white(track_title) + colored.yellow(") longer than set time limit (was ") + colored.red(printable_duration(track_duration)) + colored.yellow(" with limit ") + colored.red(printable_duration(resolve_time_limit(time_limit)*1000)) + colored.yellow(")"))
+                        continue
 
                 puts_safe(colored.green("Downloading") + colored.white(": " + track['title']))
                 if track.get('direct', False):


### PR DESCRIPTION
Code was causing errors when a time limit wasn't set. I've added sanity checks. This should fix the errors thrown in the tests from that. 

From the last pull request:

-Added a parser argument “-T, --time-limit” that accepts a duration (hh:mm:ss) to act as an upper limit so songs longer than it will not be downloaded. (example usage: “soundscrape itsvestige -l -T 10:00” will download all of Vestige’s likes that are 10 minutes or less in length)

-Added code to check the track’s duration against the upper limit parameter and output a warning string if limits are exceeded indicating that a download has been prevented.

-Added functions to resolve time to string and string to time.
(Note: internally, SoundCloud uses milliseconds for duration. It is assumed that most users will not be so specific as to prevent durations as precise as the millisecond level so for all calculations, durations are converted to seconds)