### PR TITLE
Avoid exception during file download error from aborting execution

### DIFF
--- a/soundscrape/soundscrape.py
+++ b/soundscrape/soundscrape.py
@@ -461,7 +461,7 @@ def download_tracks(client, tracks, num_tracks=sys.maxsize, downloadable=False, 
                 filenames.append(filename)
         except Exception as e:
             puts_safe(colored.red("Problem downloading ") + colored.white(track['title']))
-            puts_safe(e)
+            puts_safe(str(e))
 
     return filenames
 


### PR DESCRIPTION
Really simple fix. Was getting following exception while downloading a soundcloud playlist, which was aborting exection:
```
Problem downloading Dragonfly
'HTTPError' object has no attribute 'replace'

```

This is what we get after the fix:
```
Problem downloading Dragonfly
401 Client Error: Unauthorized for url: https://api.soundcloud.com/tracks/70493645/download?limit=200&client_id=a3dd183a357fcff9a6943c0d65664087
```

Best regards!